### PR TITLE
Use post in ticket search

### DIFF
--- a/rt_client/v2/tickets.py
+++ b/rt_client/v2/tickets.py
@@ -360,5 +360,6 @@ class TicketManager(RecordManager):
         if order_by:
             payload.update({"orderby": order_by, "order": order})
 
-        search_endpoint = "tickets?" + urlencode(payload, quote_via=quote_plus)
-        return self.client.get(search_endpoint)
+        search_endpoint = "tickets"
+
+        return self.client.post(search_endpoint, data=payload)

--- a/rt_client/v2/tickets.py
+++ b/rt_client/v2/tickets.py
@@ -347,20 +347,23 @@ class TicketManager(RecordManager):
                 http://docs.python-requests.org/en/master/_modules/requests/exceptions/
 
         """
-        payload = {
-            "query": search_query,
+        query_params = {
             "simple": 1 if simple_search else 0,
             "page": page,
             "per_page": per_page,
         }
+        post_params = {
+            "query": search_query,
+        }
 
         if fields:
-            payload.update(utils.build_fields_query(fields))
+            query_params.update(utils.build_fields_query(fields))
 
         if order_by:
-            payload.update({"orderby": order_by, "order": order})
+            query_params.update({"orderby": order_by, "order": order})
 
         search_endpoint = "tickets"
 
         # Sidestep the client.post, since it assumes POSTs are JSON-only
-        return self.client.request("POST", search_endpoint, data=payload)
+        search_endpoint = "tickets?" + urlencode(query_params, quote_via=quote_plus)
+        return self.client.request("POST", search_endpoint, data=post_params)

--- a/rt_client/v2/tickets.py
+++ b/rt_client/v2/tickets.py
@@ -362,4 +362,5 @@ class TicketManager(RecordManager):
 
         search_endpoint = "tickets"
 
-        return self.client.post(search_endpoint, data=payload)
+        # Sidestep the client.post, since it assumes POSTs are JSON-only
+        return self.client.request("POST", search_endpoint, data=payload)


### PR DESCRIPTION
Summary
Some ticket searches use parameters that may exceed server limits; this moves the main query to a POST body and keep the rest in the query string to ensure proper paging behavior.